### PR TITLE
Make regex an optional dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ path = "src/lib.rs"
 
 [dependencies]
 slog = "2"
-regex = { version = "0.1", optional = true }
+regex = { version = "0.2", optional = true }
 slog-term = "2"
 slog-stdlog = "2"
 slog-scope = "3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,8 +21,10 @@ regex = { version = "0.2", optional = true }
 slog-term = "2"
 slog-stdlog = "2"
 slog-scope = "3"
-slog-async = "2"
 log = "0.3.6"
+
+[dev-dependencies]
+slog-async = "2"
 
 [[test]]
 name = "regexp_filter"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ path = "src/lib.rs"
 
 [dependencies]
 slog = "2"
-regex = "0.1"
+regex = { version = "0.1", optional = true }
 slog-term = "2"
 slog-stdlog = "2"
 slog-scope = "3"
@@ -28,3 +28,5 @@ log = "0.3.6"
 name = "regexp_filter"
 harness = false
 
+[features]
+default = ["regex"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,7 +76,6 @@ extern crate slog;
 extern crate slog_term;
 extern crate slog_stdlog;
 extern crate slog_scope;
-extern crate slog_async;
 extern crate log;
 
 use std::{env, result, sync};

--- a/src/regex.rs
+++ b/src/regex.rs
@@ -1,0 +1,28 @@
+extern crate regex;
+
+use std::fmt;
+
+use self::regex::Regex;
+
+pub struct Filter {
+    inner: Regex,
+}
+
+impl Filter {
+    pub fn new(spec: &str) -> Result<Filter, String> {
+        match Regex::new(spec){
+            Ok(r) => Ok(Filter { inner: r }),
+            Err(e) => Err(e.to_string()),
+        }
+    }
+
+    pub fn is_match(&self, s: &str) -> bool {
+        self.inner.is_match(s)
+    }
+}
+
+impl fmt::Display for Filter {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        self.inner.fmt(f)
+    }
+}

--- a/src/string.rs
+++ b/src/string.rs
@@ -1,0 +1,21 @@
+use std::fmt;
+
+pub struct Filter {
+    inner: String,
+}
+
+impl Filter {
+    pub fn new(spec: &str) -> Result<Filter, String> {
+        Ok(Filter { inner: spec.to_string() })
+    }
+
+    pub fn is_match(&self, s: &str) -> bool {
+        s.contains(&self.inner)
+    }
+}
+
+impl fmt::Display for Filter {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        self.inner.fmt(f)
+    }
+}


### PR DESCRIPTION
Follows up the `env-logger` crate, see https://github.com/rust-lang-nursery/log/pull/96