### PR TITLE
Update deps

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,12 +17,12 @@ path = "src/lib.rs"
 
 [dependencies]
 slog = "2"
-regex = { version = "0.2", optional = true }
+regex = { version = "1.2", optional = true }
 slog-term = "2"
-slog-stdlog = "3"
+slog-stdlog = "4"
 slog-scope = "4"
 slog-async = "2"
-log = "0.3.6"
+log = "0.4"
 
 [dev-dependencies]
 slog-async = "2"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,7 +71,6 @@
        html_root_url = "http://doc.rust-lang.org/env_logger/")]
 #![cfg_attr(test, deny(warnings))]
 
-#[macro_use]
 extern crate slog;
 extern crate slog_term;
 extern crate slog_stdlog;


### PR DESCRIPTION
Update dependencies to latest version.

This is in an effort to weed out old versions of memoffset which is pulled in through old deps.