### PR TITLE
Add default feature 'init' to allow minimal builds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,11 +18,10 @@ path = "src/lib.rs"
 [dependencies]
 slog = "2"
 regex = { version = "1.2", optional = true }
-slog-term = "2"
-slog-stdlog = "4"
-slog-scope = "4"
-slog-async = "2"
-log = "0.4"
+slog-term = { version = "2", optional = true }
+slog-stdlog = { version = "4", optional = true }
+slog-scope = { version = "4", optional = true }
+log = { version = "0.4", optional = true }
 
 [dev-dependencies]
 slog-async = "2"
@@ -32,4 +31,5 @@ name = "regexp_filter"
 harness = false
 
 [features]
-default = ["regex"]
+init = ["slog-term", "slog-stdlog", "slog-scope", "log"]
+default = ["regex", "init"]

--- a/src/init.rs
+++ b/src/init.rs
@@ -1,0 +1,29 @@
+extern crate log;
+extern crate slog_scope;
+extern crate slog_stdlog;
+extern crate slog_term;
+
+use crate::new;
+use slog::*;
+use std::sync;
+
+/// Use a default `EnvLogger` as global logging drain
+///
+/// This is for lazy devs that with minimal amount of work want to convert
+/// software that used standard Rust `env_logger` crate to
+/// `slog-env_logger`.
+///
+/// It's an easy first step, but using `init()` you're not gaining almost
+/// anything that `slog` has to offer, so I highly encourage to use `new()`
+/// instead and explicitly configure your loggers.
+pub fn init() -> std::result::Result<slog_scope::GlobalLoggerGuard, log::SetLoggerError> {
+    let drain =
+        slog_term::CompactFormat::new(slog_term::TermDecorator::new().stderr().build()).build();
+    let drain = new(drain);
+    let drain = sync::Mutex::new(drain.fuse());
+
+    let guard = slog_scope::set_global_logger(Logger::root(drain.fuse(), o!()).into_erased());
+    slog_stdlog::init()?;
+
+    Ok(guard)
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,12 +72,8 @@
 #![cfg_attr(test, deny(warnings))]
 
 extern crate slog;
-extern crate slog_term;
-extern crate slog_stdlog;
-extern crate slog_scope;
-extern crate log;
 
-use std::{env, result, sync};
+use std::{env, result};
 use std::cell::RefCell;
 use slog::*;
 
@@ -88,6 +84,13 @@ mod filter;
 #[cfg(not(feature = "regex"))]
 #[path = "string.rs"]
 mod filter;
+
+#[cfg(feature = "init")]
+#[path = "init.rs"]
+mod init;
+
+#[cfg(feature = "init")]
+pub use init::init;
 
 thread_local! {
     static TL_BUF: RefCell<String> = RefCell::new(String::new())
@@ -249,28 +252,6 @@ pub fn new<T : Drain>(d : T) -> EnvLogger<T> {
     }
 
     builder.build()
-}
-
-/// Use a default `EnvLogger` as global logging drain
-///
-/// This is for lazy devs that with minimal amount of work want to convert
-/// software that used standard Rust `env_logger` crate to
-/// `slog-env_logger`.
-///
-/// It's an easy first step, but using `init()` you're not gaining almost
-/// anything that `slog` has to offer, so I highly encourage to use `new()`
-/// instead and explicitly configure your loggers.
-pub fn init() -> std::result::Result<slog_scope::GlobalLoggerGuard, log::SetLoggerError> {
-    let drain = slog_term::CompactFormat::new(
-        slog_term::TermDecorator::new().stderr().build()
-        ).build();
-    let drain = new(drain);
-    let drain = sync::Mutex::new(drain.fuse());
-
-    let guard = slog_scope::set_global_logger(Logger::root(drain.fuse(), o!()).into_erased());
-    slog_stdlog::init()?;
-
-    Ok(guard)
 }
 
 /// Parse a logging specification string (e.g: "crate1,crate2::mod3,crate3::x=error/foo")


### PR DESCRIPTION
The main feature of "slog-envlogger" is the drain that supports filtering via environment variables.

The additional `init` function requires "slog-term", "slog-stdlog", "slog-scope" and "log". "slog-async" was also included as a default dependency but it is only needed as a dev-dependency. But many users will only need `new`, not `init`.

This PR allows to build "slog-envlogger" without `init` and the extra dependencies:

```bash
$ cargo build --no-default-features
   Compiling slog v2.7.0
   Compiling slog-envlogger v2.2.0 (/path/to/envlogger)
    Finished dev [unoptimized + debuginfo] target(s) in 1.27s
```