### PR TITLE
Use Rust 2018

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 
 name = "slog-envlogger"
 version = "2.2.0"
+edition = "2018"
 authors = ["The Rust Project Developers", "Dawid Ciężarkiewicz <dpc@dpc.pw>"]
 license = "MIT/Apache-2.0"
 readme = "README.md"

--- a/examples/proper.rs
+++ b/examples/proper.rs
@@ -1,12 +1,21 @@
-extern crate slog_stdlog;
-extern crate slog_envlogger;
-extern crate slog_term;
-extern crate slog_scope;
 extern crate slog_async;
+extern crate slog_envlogger;
+extern crate slog_scope;
+extern crate slog_stdlog;
+extern crate slog_term;
 
 /// Import longer-name versions of macros only to not collide with legacy `log`
-#[macro_use(slog_error, slog_info, slog_trace, slog_log, slog_o, slog_record,
-            slog_record_static, slog_b, slog_kv)]
+#[macro_use(
+    slog_error,
+    slog_info,
+    slog_trace,
+    slog_log,
+    slog_o,
+    slog_record,
+    slog_record_static,
+    slog_b,
+    slog_kv
+)]
 extern crate slog;
 
 use slog::Drain;
@@ -15,22 +24,20 @@ use slog::Drain;
 extern crate log;
 
 fn main() {
-    let drain =
-        slog_async::Async::default(
-        slog_envlogger::new(
-        slog_term::CompactFormat::new(
-            slog_term::TermDecorator::new()
-            .stderr().build()
-            ).build().fuse()
-        ));
+    let drain = slog_async::Async::default(slog_envlogger::new(
+        slog_term::CompactFormat::new(slog_term::TermDecorator::new().stderr().build())
+            .build()
+            .fuse(),
+    ));
 
-    let root_logger = slog::Logger::root(drain.fuse(),
-                                         slog_o!("build" => "8jdkj2df", "version" => "0.1.5"));
+    let root_logger = slog::Logger::root(
+        drain.fuse(),
+        slog_o!("build" => "8jdkj2df", "version" => "0.1.5"),
+    );
 
     slog_stdlog::init().unwrap();
 
     slog_scope::scope(&root_logger, || {
-
         slog_error!(root_logger, "slog error");
         error!("log error");
         slog_info!(root_logger, "slog info");

--- a/examples/proper.rs
+++ b/examples/proper.rs
@@ -1,27 +1,7 @@
-extern crate slog_async;
-extern crate slog_envlogger;
-extern crate slog_scope;
-extern crate slog_stdlog;
-extern crate slog_term;
-
-/// Import longer-name versions of macros only to not collide with legacy `log`
-#[macro_use(
-    slog_error,
-    slog_info,
-    slog_trace,
-    slog_log,
-    slog_o,
-    slog_record,
-    slog_record_static,
-    slog_b,
-    slog_kv
-)]
-extern crate slog;
-
+use log::*;
 use slog::Drain;
-
-#[macro_use]
-extern crate log;
+/// Import longer-name versions of macros only to not collide with legacy `log`
+use slog::{slog_error, slog_info, slog_o, slog_trace};
 
 fn main() {
     let drain = slog_async::Async::default(slog_envlogger::new(

--- a/examples/scopes.rs
+++ b/examples/scopes.rs
@@ -1,6 +1,6 @@
-extern crate slog_stdlog;
 extern crate slog_envlogger;
 extern crate slog_scope;
+extern crate slog_stdlog;
 
 #[macro_use(o, kv)]
 extern crate slog;
@@ -15,7 +15,7 @@ fn main() {
 
     slog_scope::scope(
         &slog_scope::logger().new(o!("scope-extra-data" => "data")),
-        || foo()
+        || foo(),
     );
 
     trace!("log trace");
@@ -27,7 +27,7 @@ fn foo() {
     // scopes can be nested!
     slog_scope::scope(
         &slog_scope::logger().new(o!("even-more-scope-extra-data" => "data2")),
-        || bar()
+        || bar(),
     );
 }
 

--- a/examples/scopes.rs
+++ b/examples/scopes.rs
@@ -1,12 +1,5 @@
-extern crate slog_envlogger;
-extern crate slog_scope;
-extern crate slog_stdlog;
-
-#[macro_use(o, kv)]
-extern crate slog;
-
-#[macro_use]
-extern crate log;
+use log::*;
+use slog::o;
 
 fn main() {
     let _guard = slog_envlogger::init().unwrap();

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -1,8 +1,4 @@
-extern crate slog_envlogger;
-extern crate slog_stdlog;
-
-#[macro_use]
-extern crate log;
+use log::*;
 
 fn main() {
     let _guard = slog_envlogger::init().unwrap();

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -1,5 +1,5 @@
-extern crate slog_stdlog;
 extern crate slog_envlogger;
+extern crate slog_stdlog;
 
 #[macro_use]
 extern crate log;

--- a/src/init.rs
+++ b/src/init.rs
@@ -1,8 +1,3 @@
-extern crate log;
-extern crate slog_scope;
-extern crate slog_stdlog;
-extern crate slog_term;
-
 use crate::new;
 use slog::*;
 use std::sync;

--- a/src/regex.rs
+++ b/src/regex.rs
@@ -10,7 +10,7 @@ pub struct Filter {
 
 impl Filter {
     pub fn new(spec: &str) -> Result<Filter, String> {
-        match Regex::new(spec){
+        match Regex::new(spec) {
             Ok(r) => Ok(Filter { inner: r }),
             Err(e) => Err(e.to_string()),
         }

--- a/src/regex.rs
+++ b/src/regex.rs
@@ -1,8 +1,5 @@
-extern crate regex;
-
+use regex::Regex;
 use std::fmt;
-
-use self::regex::Regex;
 
 pub struct Filter {
     inner: Regex,
@@ -22,7 +19,7 @@ impl Filter {
 }
 
 impl fmt::Display for Filter {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.inner.fmt(f)
     }
 }

--- a/src/string.rs
+++ b/src/string.rs
@@ -6,7 +6,9 @@ pub struct Filter {
 
 impl Filter {
     pub fn new(spec: &str) -> Result<Filter, String> {
-        Ok(Filter { inner: spec.to_string() })
+        Ok(Filter {
+            inner: spec.to_string(),
+        })
     }
 
     pub fn is_match(&self, s: &str) -> bool {

--- a/src/string.rs
+++ b/src/string.rs
@@ -17,7 +17,7 @@ impl Filter {
 }
 
 impl fmt::Display for Filter {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.inner.fmt(f)
     }
 }

--- a/tests/regexp_filter.rs
+++ b/tests/regexp_filter.rs
@@ -1,8 +1,9 @@
-#[macro_use] extern crate log;
+#[macro_use]
+extern crate log;
 extern crate slog_envlogger;
 
-use std::process;
 use std::env;
+use std::process;
 use std::str;
 
 fn main() {
@@ -14,7 +15,7 @@ fn main() {
 }
 
 fn child_main() {
-    let _guard =slog_envlogger::init().unwrap();
+    let _guard = slog_envlogger::init().unwrap();
     info!("XYZ Message");
 }
 
@@ -25,7 +26,9 @@ fn run_child(rust_log: String) -> bool {
         .env("RUST_LOG", rust_log)
         .output()
         .unwrap_or_else(|e| panic!("Unable to start child process: {}", e));
-    str::from_utf8(out.stderr.as_ref()).unwrap().contains("XYZ Message")
+    str::from_utf8(out.stderr.as_ref())
+        .unwrap()
+        .contains("XYZ Message")
 }
 
 fn assert_message_printed(rust_log: &str) {
@@ -36,7 +39,10 @@ fn assert_message_printed(rust_log: &str) {
 
 fn assert_message_not_printed(rust_log: &str) {
     if run_child(rust_log.to_string()) {
-        panic!("RUST_LOG={} should not allow the test log message", rust_log)
+        panic!(
+            "RUST_LOG={} should not allow the test log message",
+            rust_log
+        )
     }
 }
 

--- a/tests/regexp_filter.rs
+++ b/tests/regexp_filter.rs
@@ -1,7 +1,4 @@
-#[macro_use]
-extern crate log;
-extern crate slog_envlogger;
-
+use log::*;
 use std::env;
 use std::process;
 use std::str;


### PR DESCRIPTION
This updates envlogger to use Rust 2018. I split it into two commits to make it easier to follow the changes:
- Use `cargo fmt`, applying the Rust 2018 style.
- Fix clippy warnings (`cargo clippy --all --workspace --all-features -- -Dwarnings -Drust-2018-idioms`)
