### PR TITLE
Fix license field to be a valid SPDX expression

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@
 name = "slog-envlogger"
 version = "2.2.0"
 authors = ["The Rust Project Developers", "Dawid Ciężarkiewicz <dpc@dpc.pw>"]
-license = "MIT/Apache-2.0"
+license = "MIT OR Apache-2.0"
 readme = "README.md"
 documentation = "https://docs.rs/slog-envlogger"
 homepage = "https://github.com/slog-rs/slog"


### PR DESCRIPTION
The Cargo.toml license field must be a valid SPDX expression.

A similar fix was made to slog back in 2018, but it appears that the associated slog feature crates were not updated.
https://github.com/slog-rs/slog/pull/193